### PR TITLE
Update RBAC policies

### DIFF
--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -16,6 +16,9 @@ rules:
 - apiGroups: ["templates.gatekeeper.sh"]
   resources: ["*"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["config.gatekeeper.sh"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
 
 ---
 


### PR DESCRIPTION
The service account has missing permissions for the GPM to be able to have read access to `config.gatekeeper.sh` apigroup. 

- Adding 
```
- apiGroups: ["config.gatekeeper.sh"]
  resources: ["*"]
  verbs: ["get", "list", "watch"]
```

![image](https://user-images.githubusercontent.com/20175487/95104077-45e9db80-06ea-11eb-9a93-fc6b06f275e9.png)
