### PR TITLE
configs view throws 404

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -319,14 +319,22 @@ def get_gatekeeperconfigs():
             description=e,
         )
     except ApiException as e:
-        return render_template(
-            "message.html",
-            type="error",
-            title="Error",
-            message="We had a problem while asking the API for Gatekeeper Config objects",
-            action="Is Gatekeeper deployed in the cluster?",
-            description=e,
-        )
+        if e.status == 404:
+            return render_template(
+                "configs.html",
+                gatekeeper_configs=[],
+                title="Gatekeeper Configurations",
+                hide_sidebar=True,
+            )
+        else:
+            return render_template(
+                "message.html",
+                type="error",
+                title="Error",
+                message="We had a problem while asking the API for Gatekeeper Config objects",
+                action="Is Gatekeeper deployed in the cluster?",
+                description=e,
+            )
     except ConfigException as e:
         return render_template(
             "message.html",

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,9 +21,6 @@
 </head>
 
 <body style="background-color: #f0f0f0;">
-  <script src="{{ url_for('static', filename='node_modules/jquery/dist/jquery.min.js') }}"></script>
-  <script src="{{ url_for('static', filename='node_modules/fomantic-ui-css/semantic.min.js') }}"></script>
-  <script src="{{ url_for('static', filename='prism.js') }}"></script>
   <div class="ui top secondary pointing menu">
     <a class="header item" href="/">
       <i class="user tie icon"></i>
@@ -63,11 +60,16 @@
 
   {% include 'footer.html' %}
 
+  <script src="{{ url_for('static', filename='node_modules/jquery/dist/jquery.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='node_modules/fomantic-ui-css/semantic.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='prism.js') }}"></script>
+
   <script>
     $('.ui.accordion')
       .accordion()
       ;
   </script>
+
 </body>
 
 </html>


### PR DESCRIPTION
The configs view gave a 404 error message when there were no configs CRDs on the cluster. Let's handle better that case and show that there are no configs instead of an error.

As a bonus fix the order of the JS scripts tags so we get rid of unwanted space in the toolbar.