### PR TITLE
Bumpversion config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,14 @@
+[bumpversion]
+commit = True
+tag = True
+current_version = 0.3.0
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
+serialize = 
+	{major}.{minor}.{patch}-rc{rc}
+	{major}.{minor}.{patch}
+
+[bumpversion:file:README.md]
+
+[bumpversion:file:kustomization.yaml]
+
+[bumpversion:file:app/templates/footer.html]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 0.3.0
+current_version = 0.3.0-rc1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-rc{rc}
@@ -12,3 +12,4 @@ serialize =
 [bumpversion:file:kustomization.yaml]
 
 [bumpversion:file:app/templates/footer.html]
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Gatekeeper Policy Manager Changelog
 
-## v0.3
+## v0.3.0
 
 - Added support for offline frontend usage.
 - Added favicon.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Then access it with your browser on: [http://127.0.0.1:8080](http://127.0.0.1:80
 GPM can also be run locally using docker and a `kubeconfig`, assuming that the `kubeconfig` file you want to use is located at `~/.kube/config` the command to run GPM locally would be:
 
 ```bash
-docker run -v ~/.kube/config:/root/.kube/config -p 8080:8080 quay.io/sighup/gatekeeper-policy-manager:v0.3.0
+docker run -v ~/.kube/config:/root/.kube/config -p 8080:8080 quay.io/sighup/gatekeeper-policy-manager:v0.3.0-rc1
 ```
 
 Then access it with your browser on: [http://127.0.0.1:8080](http://127.0.0.1:8080)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Gatekeeper Policy Manager (GPM)
 
+[![Build Status](https://ci.sighup.io/api/badges/sighupio/gatekeeper-policy-manager/status.svg)](https://ci.sighup.io/sighupio/gatekeeper-policy-manager)
+
 Gatekeeper Policy Manager is a simple **read-only** web UI for viewing OPA Gatekeeper policies' status in a Kubernetes Cluster.
 
 It can display all the defined **Constraint Templates** with their rego code, and all the **Contraints** with its current status, violations, enforcement action, matches definitions, etc.
@@ -35,7 +37,7 @@ Then access it with your browser on: [http://127.0.0.1:8080](http://127.0.0.1:80
 GPM can also be run locally using docker and a `kubeconfig`, assuming that the `kubeconfig` file you want to use is located at `~/.kube/config` the command to run GPM locally would be:
 
 ```bash
-docker run -v ~/.kube/config:/root/.kube/config -p 8080:8080 quay.io/sighup/gatekeeper-policy-manager:0.3
+docker run -v ~/.kube/config:/root/.kube/config -p 8080:8080 quay.io/sighup/gatekeeper-policy-manager:v0.3.0
 ```
 
 Then access it with your browser on: [http://127.0.0.1:8080](http://127.0.0.1:8080)

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -6,7 +6,7 @@
 
 <div class="ui inverted vertical footer segment">
   <div class="ui container">
-    <h4 class="ui inverted header">Gatekeeper Policy Manager v0.3.0</h4>
+    <h4 class="ui inverted header">Gatekeeper Policy Manager v0.3.0-rc1</h4>
     <p>A simple to use web-based Gatekeeper policies manager</p>
     <p><i class="red heart icon"></i> Proud part of the <a href="https://kubernetesfury.com">Kubernetes Fury
         Distribution</a></p>

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -6,7 +6,7 @@
 
 <div class="ui inverted vertical footer segment">
   <div class="ui container">
-    <h4 class="ui inverted header">Gatekeeper Policy Manager v0.3</h4>
+    <h4 class="ui inverted header">Gatekeeper Policy Manager v0.3.0</h4>
     <p>A simple to use web-based Gatekeeper policies manager</p>
     <p><i class="red heart icon"></i> Proud part of the <a href="https://kubernetesfury.com">Kubernetes Fury
         Distribution</a></p>

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -19,4 +19,4 @@ resources:
 
 images:
   - name: quay.io/sighup/gatekeeper-policy-manager
-    newTag: "0.3"
+    newTag: "v0.3.0"

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -19,4 +19,4 @@ resources:
 
 images:
   - name: quay.io/sighup/gatekeeper-policy-manager
-    newTag: "v0.3.0"
+    newTag: "v0.3.0-rc1"

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -26,7 +26,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gatekeeper-policy-manager-crd-view


### PR DESCRIPTION
Hi!

This PR includes a configuration file to use with bumpversion to easily release a new version just taking care about running the right bumpversion command:

```bash
$ bumpvesion patch
# or
$ bumpvesion minor
# or
$ bumpvesion major
```

Then
```bash
$ git push origin master --tags
```

It includes a small fix in the `ClusterRoleBinding` apiversion. (Spotted by deprek8ion).

Thanks!