### PR TITLE
Add automatic e2e tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,10 +19,6 @@ name: policeman
 depends_on:
   - license
 
-platform:
-  os: linux
-  arch: amd64
-
 steps:
   - name: lint
     image: quay.io/sighup/policeman
@@ -50,18 +46,117 @@ steps:
 
 ---
 kind: pipeline
+name: e2e
+
+depends_on:
+  - policeman
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+      - refs/heads/master
+      - refs/heads/renovate/*
+
+steps:
+  - name: build
+    image: docker:dind
+    pull: always
+    environment:
+      CACHE_FROM: quay.io/sighup/gatekeeper-policy-manager:unstable
+      CONTAINER_IMAGE_NAME: gatekeeper-policy-manager
+      CONTAINER_IMAGE_TAG: test-${DRONE_BUILD_NUMBER}
+      DOCKERFILE: Dockerfile
+      BUILD_CONTEXT: "."
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    commands:
+      - docker pull $${CACHE_FROM}
+      - docker build
+        --pull=true
+        --rm=true
+        --cache-from $${CACHE_FROM}
+        -f $${DOCKERFILE}
+        -t $${CONTAINER_IMAGE_NAME}:$${CONTAINER_IMAGE_TAG}
+        $${BUILD_CONTEXT}
+
+  - name: kind
+    image: docker:dind
+    pull: always
+    environment:
+      KIND_VERSION: v0.9.0
+      CLUSTER_VERSION: v1.19.1
+      LOAD_IMAGE: gatekeeper-policy-manager:test-${DRONE_BUILD_NUMBER}
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    commands:
+      - wget -qO /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/$${KIND_VERSION}/kind-$(uname)-amd64"
+      - wget -qO /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$${CLUSTER_VERSION}/bin/linux/amd64/kubectl"
+      - chmod +x /usr/local/bin/kind /usr/local/bin/kubectl
+      - kind create cluster --name $${CLUSTER_NAME} --image kindest/node:$${CLUSTER_VERSION}
+      - kind load docker-image $${LOAD_IMAGE} --name $${CLUSTER_NAME}
+      - kind get kubeconfig --name $${CLUSTER_NAME} > kubeconfig.yml
+
+  - name: tests
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.19.0_3.3.0_2.4.1
+    pull: always
+    network_mode: host
+    environment:
+      KUBECONFIG: /tmp/kubeconfig.yml
+      LOAD_IMAGE: gatekeeper-policy-manager:test-${DRONE_BUILD_NUMBER}
+    commands:
+      - mv kubeconfig.yml $${KUBECONFIG}
+      - cd tests
+      - kustomize edit set image quay.io/sighup/gatekeeper-policy-manager=$${LOAD_IMAGE}
+      - cd -
+      - bats -t tests/tests.sh
+
+  - name: kind-destroy
+    image: docker:dind
+    pull: always
+    environment:
+      KIND_VERSION: v0.9.0
+      LOAD_IMAGE: gatekeeper-policy-manager:test-${DRONE_BUILD_NUMBER}
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    commands:
+      - docker rmi $${LOAD_IMAGE}
+      - wget -qO /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/$${KIND_VERSION}/kind-$(uname)-amd64"
+      - chmod +x /usr/local/bin/kind
+      - kind delete cluster --name $${CLUSTER_NAME}
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+
+---
+kind: pipeline
 name: release
 
 depends_on:
   - license
   - policeman
+  - e2e
 
-platform:
-  os: linux
-  arch: amd64
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+      - refs/heads/**
+    exclude:
+      - refs/heads/renovate/*
 
 steps:
-
   - name: registry-sha
     image: plugins/docker
     settings:

--- a/tests/deploy-patch.yaml
+++ b/tests/deploy-patch.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gatekeeper-policy-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: gatekeeper-policy-manager
+        imagePullPolicy: IfNotPresent

--- a/tests/e2e-tests.yaml
+++ b/tests/e2e-tests.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: e2e-tests
+spec:
+  template:
+    spec:
+      containers:
+      - name: configs
+        image: docker.io/curlimages/curl
+        command: ["/bin/sh",  "-c"]
+        args: ["curl -s http://gatekeeper-policy-manager.gatekeeper-system.svc.cluster.local/configs/ | grep 'kube-system'"]
+      - name: constrainttemplates
+        image: docker.io/curlimages/curl
+        command: ["/bin/sh",  "-c"]
+        args: ["curl -s http://gatekeeper-policy-manager.gatekeeper-system.svc.cluster.local/constrainttemplates/ | grep 'Target admission.k8s.gatekeeper.sh'"]
+      - name: constraints
+        image: docker.io/curlimages/curl
+        command: ["/bin/sh",  "-c"]
+        args: ["curl -s http://gatekeeper-policy-manager.gatekeeper-system.svc.cluster.local/constraints/ | grep 'local-path-provisioner in the Deployment local-path-provisioner does not have a memory limit set'"]
+      restartPolicy: Never
+  backoffLimit: 10

--- a/tests/helper.bash
+++ b/tests/helper.bash
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+# shellcheck disable=SC2086,SC2154,SC2034
+
+apply (){
+  kustomize build $1 >&2
+  kustomize build $1 | kubectl apply -f - 2>&3
+}
+
+delete (){
+  kustomize build $1 >&2
+  kustomize build $1 | kubectl delete -f - 2>&3
+}
+
+info(){
+  echo -e "${BATS_TEST_NUMBER}: ${BATS_TEST_DESCRIPTION}" >&3
+}
+
+loop_it(){
+  retry_counter=0
+  max_retry=${2:-100}
+  wait_time=${3:-2}
+  run ${1}
+  ko=${status}
+  loop_it_result=${ko}
+  while [[ ko -ne 0 ]]
+  do
+    if [ $retry_counter -ge $max_retry ]; then echo "Timeout waiting a condition"; return 1; fi
+    sleep ${wait_time} && echo "# waiting..." $retry_counter >&3
+    run ${1}
+    ko=${status}
+    loop_it_result=${ko}
+    retry_counter=$((retry_counter + 1))
+  done
+  return 0
+}

--- a/tests/kustomization.yaml
+++ b/tests/kustomization.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+namespace: gatekeeper-system
+
+bases:
+  - github.com/sighupio/fury-kubernetes-opa/katalog/gatekeeper?ref=v1.2.1
+
+resources:
+  - ../manifests/rbac.yaml
+  - ../manifests/deployment.yaml
+  - ../manifests/service.yaml
+
+patchesStrategicMerge:
+  - deploy-patch.yaml
+
+images:
+  - name: quay.io/sighup/gatekeeper-policy-manager
+    newName: gatekeeper-policy-manager
+    newTag: test

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Requirements" {
+    info
+    ns(){
+        kubectl create ns gatekeeper-system
+        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.2/katalog/prometheus-operator/crd-servicemonitor.yml
+    }
+    run ns
+    [ "$status" -eq 0 ]
+}
+
+@test "Deploy" {
+    info
+    deploy(){
+        kustomize build --load_restrictor none tests/ | kubectl apply -f -
+    }
+    loop_it deploy 30 5
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Wait until GPM is ready" {
+    info
+    ready(){
+        kubectl -n gatekeeper-system wait --for=condition=available --timeout=300s deployment/gatekeeper-policy-manager
+    }
+    run ready
+    [ "$status" -eq 0 ]
+}
+
+@test "Run tests" {
+    info
+    deploy_test(){
+        kubectl -n kube-system apply -f tests/e2e-tests.yaml
+    }
+    run deploy_test
+    [ "$status" -eq 0 ]
+}
+
+@test "Check tests" {
+    info
+    test(){
+        kubectl -n kube-system wait --for=condition=complete --timeout=30s job/e2e-tests
+    }
+    run test
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Hi!

This PR adds an e2e testing pipeline.
~**Pending to create the final tests.**~
Currently, it provides all the components and structure to run e2e tests in an automatic manner.

Pipelines now have some conditions:

- License and Policeman runs always
- e2e Pipeline runs on `tags`, `master`, and `renovate` branches.
- Release pipeline runs on `tags` and `push` events excluding `renovate` branches.

This way, we can automate test renovate PRs.