### PR TITLE
Revert "Update dependency lazy-object-proxy to v1.5.1"

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -18,7 +18,7 @@ isort==4.3.21
 itsdangerous==1.1.0
 Jinja2==2.11.2
 kubernetes==11.0.0
-lazy-object-proxy==1.5.1
+lazy-object-proxy==1.4.3
 Mako==1.1.3
 MarkupSafe==1.1.1
 mccabe==0.6.1


### PR DESCRIPTION
Reverts sighupio/gatekeeper-policy-manager#21

`astroid 2.4.2 has requirement lazy-object-proxy==1.4.*, but you'll have lazy-object-proxy 1.5.1 which is incompatible.`