### PR TITLE
Update the uWSGI buffer size.

### DIFF
--- a/app/uwsgi.ini
+++ b/app/uwsgi.ini
@@ -2,3 +2,4 @@
 module = app
 callable = app
 master = true
+buffer-size = 65535


### PR DESCRIPTION
**Error :** 
```
invalid request block size: 5292 (max 4096)...skip
10.x.x.x - - [02/Nov/2020:08:33:43 +0000] "GET /favicon.ico HTTP/1.1" 502 560 "https://gpm.<redacted>/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.111 Safari/537.36" "10.x.x.x"
2020/11/02 08:33:43 [error] 10#10: *16 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: 10.x.x.x.x, server: , request: "GET /favicon.ico HTTP/1.1", upstream: "uwsgi://unix:///tmp/uwsgi.sock:", host: "gpm.<redacted>", referrer: "https://gpm.<redacted>/"
```
**Reason:** 

By default, uWSGI allocates a very small buffer (4096 bytes) for the headers of each request. If you start receiving “invalid request block size” in your logs, it could mean you need a bigger buffer. Increase it (up to 65535) with the buffer-size option.
Reference: https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html

- Most modern proxies exceed this buffer size (Okta, Auth0, dex). I tested this with okta and dex. You can also make it configurable if you like. 
- Having said that - the buffer size can also be controlled at the ingress controller level (For example nginx - `proxy-buffer-size`)

**Sample nginx configuration for reference**
```
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  annotations:
    acme.cert-manager.io/http01-ingress-class: nginx
    cert-manager.io/cluster-issuer: letsencrypt-prod
    kubernetes.io/ingress.class: nginx
    kubernetes.io/tls-acme: "true"
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=https://$host$request_uri$is_args$args
    nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
    nginx.ingress.kubernetes.io/secure-backends: "true"
    nginx.ingress.kubernetes.io/configuration-snippet: |
     auth_request_set $token $upstream_http_authorization;
     proxy_set_header Authorization $token;
  name: gatekeeper-policy-manager
  namespace: gatekeeper-system
spec:
  rules:
  # Set the HOST accordingly
  - host: gpm.<redacted>
    http:
      paths:
      - backend:
          serviceName: gatekeeper-policy-manager
          servicePort: http
  tls:
  - hosts:
    - gpm.<redacted>
    secretName: gpm-<redacted>
```
