### PR TITLE
[Enhancement] Helm-ify the gatekeeper-policy-manager

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: gatekeeper-policy-manager
+description: A Helm chart for Gatekeeper Policy Manager which is a simple read-only web UI for
+             viewing OPA Gatekeeper policies' status in a Kubernetes Cluster.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.4.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: v0.4.0

--- a/chart/README.md
+++ b/chart/README.md
@@ -13,10 +13,10 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 If you have custom options or values you want to override:
 Navigate to the chart/ folder and 
 
+**On Helm3**
 ```bash
-  helm install . --namespace gpm -f my-gpm-values.yaml --name gpm
+  helm install gpm . --namespace gpm -f my-gpm-values.yaml
 ```
-
 * Specific versions of the chart can be installed using the `--version` option, with the default being the latest release.
 * You can also use `--dry-run --debug` flags to see the computed values.
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,31 @@
+# Helm Chart for Gatekeper Policy Manager(GPM)
+A Helm chart that deploys Gatekeeper Policy Manager on Kubernetes.
+
+## Before you start
+
+Before you install this chart you must create a namespace for it, this is due to the order in which the resources in the charts are applied (Helm collects all of the resources in a given Chart and it's dependencies, groups them by resource type, and then installs them in a predefined order.
+
+## Installation
+
+[Helm](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+If you have custom options or values you want to override:
+Navigate to the chart/ folder and 
+
+```bash
+  helm install . --namespace gpm -f my-gpm-values.yaml --name gpm
+```
+
+* Specific versions of the chart can be installed using the `--version` option, with the default being the latest release.
+* You can also use `--dry-run --debug` flags to see the computed values.
+
+As part of this chart many different pods and services are installed which all
+have varying resource requirements.
+
+## Chart Values
+Refer to values.yaml template to override the defaults. The values can be overriden at runtime using `--set-string` option. 
+
+For example : 
+By setting the value of securityContext.runAsUser to "", K8s chooses a valid User.
+`--set-string securityContext.runAsUser=""`

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "gatekeeper-policy-manager.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "gatekeeper-policy-manager.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "gatekeeper-policy-manager.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "gatekeeper-policy-manager.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gatekeeper-policy-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gatekeeper-policy-manager.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gatekeeper-policy-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gatekeeper-policy-manager.labels" -}}
+helm.sh/chart: {{ include "gatekeeper-policy-manager.chart" . }}
+{{ include "gatekeeper-policy-manager.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gatekeeper-policy-manager.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gatekeeper-policy-manager.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gatekeeper-policy-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gatekeeper-policy-manager.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the cluster role to use.
+*/}}
+{{- define "gatekeeper-policy-manager.clusterRoleName" -}}
+{{- if .Values.clusterRole.create -}}
+    {{ default (include "gatekeeper-policy-manager.fullname" .) .Values.clusterRole.name }}
+{{- else -}}
+    {{ default "default" .Values.clusterRole.name }}
+{{- end -}}
+{{- end -}}
+

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gatekeeper-policy-manager.fullname" . }}
+  labels:
+    {{- include "gatekeeper-policy-manager.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "gatekeeper-policy-manager.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "gatekeeper-policy-manager.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gatekeeper-policy-manager.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          {{- if .Values.extraEnvs }}
+          env:
+            {{ toYaml .Values.extraEnvs | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "gatekeeper-policy-manager.fullname" . }}
+  labels:
+    {{- include "gatekeeper-policy-manager.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "gatekeeper-policy-manager.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "gatekeeper-policy-manager.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "gatekeeper-policy-manager.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.rbac.create (eq .Values.clusterRole.create true) -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "gatekeeper-policy-manager.clusterRoleName" . }}
+  labels:
+    app: {{ template "gatekeeper-policy-manager.name" . }}
+    chart: {{ template "gatekeeper-policy-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: ["constraints.gatekeeper.sh"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["templates.gatekeeper.sh"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["config.gatekeeper.sh"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "gatekeeper-policy-manager.clusterRoleName" . }}
+  labels:
+    app: {{ template "gatekeeper-policy-manager.name" . }}
+    chart: {{ template "gatekeeper-policy-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "gatekeeper-policy-manager.clusterRoleName" . }}
+subjects:
+  - name: {{ template "gatekeeper-policy-manager.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+{{- end -}}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gatekeeper-policy-manager.fullname" . }}
+  labels:
+    {{- include "gatekeeper-policy-manager.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gatekeeper-policy-manager.selectorLabels" . | nindent 4 }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gatekeeper-policy-manager.serviceAccountName" . }}
+  labels:
+    {{- include "gatekeeper-policy-manager.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/tests/test-connection.yaml
+++ b/chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "gatekeeper-policy-manager.fullname" . }}-test-connection"
+  labels:
+    {{- include "gatekeeper-policy-manager.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "gatekeeper-policy-manager.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,140 @@
+# Default values for gatekeeper-policy-manager.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+
+image:
+  repository: quay.io/sighup/gatekeeper-policy-manager
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "gatekeeper-policy-manager"
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    #kubernetes.io/ingress.class: "nginx"
+    #nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    #nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=https://$host$request_uri$is_args$args
+    #nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
+    #nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+    #nginx.ingress.kubernetes.io/secure-backends: "true"
+    #nginx.ingress.kubernetes.io/configuration-snippet: |
+    # auth_request_set $token $upstream_http_authorization;
+    # proxy_set_header Authorization $token;
+  hosts:
+    - host: gpm.local
+      paths: []
+  tls: []
+  #  - secretName: gpm-tls
+  #    hosts:
+  #      - gpm.local
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+   limits:
+     cpu: 100m
+     memory: 128Mi
+   requests:
+     cpu: 100m
+     memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Extra env variables to pass to the gatekeeper-policy-manager container
+# Uncomment and add OIDC variables for enabling OIDC
+extraEnvs: []
+#  - name: GPM_OIDC_REDIRECT_DOMAIN
+#    value: "127-0-0-1.nip.io:8080"
+#  - name: GPM_SECRET_KEY
+#    value: "changeme!"
+#    # YOU SHOULD USE A KUBERNETES SECRET INSTEAD.
+#    # valueFrom:
+#    #   secretKeyRef:
+#    #     name: gpm-secrets
+#    #     key: secret-key
+#  - name: GPM_PREFERRED_URL_SCHEME
+#    value: http
+#  - name: GPM_AUTH_ENABLED
+#    value: "OIDC"
+#  - name: GPM_OIDC_CLIENT_ID
+#    value: gatekeeper-policy-manager
+#  - name: GPM_OIDC_CLIENT_SECRET
+#    value: "30d6b009-9ae4-42b0-a5c0-b4f65aa6451e"
+#    # YOU SHOULD USE A KUBERNETES SECRET INSTEAD.
+#    # valueFrom:
+#    #   secretKeyRef:
+#    #     name: gpm-secrets
+#    #     key: oidc-client-secret
+#    # The following URLs are an example of a Keycloak OIDC provider:
+#  - name: GPM_OIDC_ISSUER
+#    value: http://192.168.1.6:8081/auth/realms/devops
+#  - name: GPM_OIDC_AUTHORIZATION_ENDPOINT
+#    value: http://192.168.1.6:8081/auth/realms/devops/protocol/openid-connect/auth
+#  - name: GPM_OIDC_JWKS_URI
+#    value: http://192.168.1.6:8081/auth/realms/devops/protocol/openid-connect/certs
+#  - name: GPM_OIDC_TOKEN_ENDPOINT
+#    value: http://192.168.1.6:8081/auth/realms/devops/protocol/openid-connect/token
+#  - name: GPM_OIDC_INTROSPECTION_ENDPOINT
+#    value: http://192.168.1.6:8081/auth/realms/devops/protocol/openid-connect/token/introspect
+#  - name: GPM_OIDC_USERINFO_ENDPOINT
+#    value: http://192.168.1.6:8081/auth/realms/devops/protocol/openid-connect/userinfo
+#  - name: GPM_OIDC_END_SESSION_ENDPOINT
+#    value: http://192.168.1.6:8081/auth/realms/devops/protocol/openid-connect/logout
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+# If create is `false` the Helm Operator will be restricted to the namespace
+# where it is deployed, and no ClusterRole or ClusterRoleBinding will be created.
+# Additionally, the kubeconfig default context will be set to that namespace.
+clusterRole:
+  create: true
+  # The name of a cluster role to bind to; if not set and create is
+  # true, a name based on fullname is generated
+  name: "gatekeeper-policy-manager-crd-view"


### PR DESCRIPTION
Helm charts are a very convenient way to manage and deploy application packages on Kubernetes. 

**Suggestion**
- It would be a good idea to publish this chart either on a standalone repository which can be hosted on GitHub itself. Github action can be leveraged publishing the charts automatically.
- https://artifacthub.io/ could be another alternative as well to increase the visibility of this package.

Tested on Kubernetes 1.17 with Helm3
![image](https://user-images.githubusercontent.com/20175487/98849867-bb8f4880-2408-11eb-800a-b501dda4e668.png)

