### PR TITLE
Pipeline improvements

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -72,6 +72,8 @@ steps:
       DOCKERFILE: Dockerfile
       BUILD_CONTEXT: "."
     volumes:
+      - name: dockerconfig
+        path: /root/.docker/config.json
       - name: dockersock
         path: /var/run/docker.sock
     commands:
@@ -83,6 +85,9 @@ steps:
         $${BUILD_CONTEXT}
 
 volumes:
+  - name: dockerconfig
+    host:
+      path: /root/.docker/config.json
   - name: dockersock
     host:
       path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -105,24 +105,27 @@ trigger:
       - refs/heads/master
       - refs/heads/renovate/*
       - refs/heads/gunicorn
+      - refs/heads/pipeline-improvements
 
 steps:
   - name: kind
     image: docker:dind
     pull: always
     environment:
-      KIND_VERSION: v0.9.0
-      CLUSTER_VERSION: v1.19.1
+      KIND_VERSION: v0.11.1
+      CLUSTER_VERSION: v1.21.2
       LOAD_IMAGE: gatekeeper-policy-manager:test-${DRONE_BUILD_NUMBER}
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}
     volumes:
+      - name: dockerconfig
+        path: /root/.docker/config.json
       - name: dockersock
         path: /var/run/docker.sock
     commands:
       - wget -qO /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/$${KIND_VERSION}/kind-$(uname)-amd64"
       - wget -qO /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$${CLUSTER_VERSION}/bin/linux/amd64/kubectl"
       - chmod +x /usr/local/bin/kind /usr/local/bin/kubectl
-      - kind create cluster --name $${CLUSTER_NAME} --image kindest/node:$${CLUSTER_VERSION}
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION}
       - kind load docker-image $${LOAD_IMAGE} --name $${CLUSTER_NAME}
       - kind get kubeconfig --name $${CLUSTER_NAME} > kubeconfig.yml
 
@@ -144,9 +147,11 @@ steps:
     image: docker:dind
     pull: always
     environment:
-      KIND_VERSION: v0.9.0
+      KIND_VERSION: v0.11.1
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}
     volumes:
+      - name: dockerconfig
+        path: /root/.docker/config.json
       - name: dockersock
         path: /var/run/docker.sock
     commands:
@@ -159,6 +164,9 @@ steps:
         - failure
 
 volumes:
+  - name: dockerconfig
+    host:
+      path: /root/.docker/config.json
   - name: dockersock
     host:
       path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -224,8 +224,6 @@ steps:
       container_image_name: gatekeeper-policy-manager
       container_image_tag: test-${DRONE_BUILD_NUMBER}
     volumes:
-      - name: dockerconfig
-        path: /root/.docker/config.json
       - name: dockersock
         path: /var/run/docker.sock
     commands:
@@ -253,8 +251,6 @@ steps:
       container_image_name: gatekeeper-policy-manager
       container_image_tag: test-${DRONE_BUILD_NUMBER}
     volumes:
-      - name: dockerconfig
-        path: /root/.docker/config.json
       - name: dockersock
         path: /var/run/docker.sock
     commands:
@@ -321,9 +317,6 @@ steps:
           - refs/tags/v**
 
 volumes:
-  - name: dockerconfig
-    host:
-      path: /root/.docker/config.json
   - name: dockersock
     host:
       path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -216,6 +216,8 @@ steps:
       container_image_name: gatekeeper-policy-manager
       container_image_tag: test-${DRONE_BUILD_NUMBER}
     volumes:
+      - name: dockerconfig
+        path: /root/.docker/config.json
       - name: dockersock
         path: /var/run/docker.sock
     commands:
@@ -243,6 +245,8 @@ steps:
       container_image_name: gatekeeper-policy-manager
       container_image_tag: test-${DRONE_BUILD_NUMBER}
     volumes:
+      - name: dockerconfig
+        path: /root/.docker/config.json
       - name: dockersock
         path: /var/run/docker.sock
     commands:
@@ -309,6 +313,9 @@ steps:
           - refs/tags/v**
 
 volumes:
+  - name: dockerconfig
+    host:
+      path: /root/.docker/config.json
   - name: dockersock
     host:
       path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -104,8 +104,6 @@ trigger:
       - refs/tags/**
       - refs/heads/master
       - refs/heads/renovate/*
-      - refs/heads/gunicorn
-      - refs/heads/pipeline-improvements
 
 steps:
   - name: kind


### PR DESCRIPTION
Ciao Ramiro!

This PR contains a couple of improvements/fixes:

1. Avoid dockerhub rate limit on build step.
  Seems like using just the socket is not enough to authenticate requests against dockerhub, so I have mounted the credentials into the `docker:dind` container that builds the application.

2. Improve and update the e2e pipeline.
  Again, it runs on kind on top of `docker:dind` container image. I've mounted the credentials here too to avoid rate limits. Then, i've updated the `kind` binary and the `cluster version`. Finally, we use our own registry to pull the `kindest/node` image. Bonus: I've removed the `gunicorn` branch trigger from the e2e pipeline.

Let me know if everything looks fine to you.