### PR TITLE
Fix correct handling of missing properties

### DIFF
--- a/app/templates/constrainttemplates.html
+++ b/app/templates/constrainttemplates.html
@@ -56,6 +56,7 @@
     {% endfor %}
 
     {% if constrainttemplate.spec.crd.spec.validation is defined and constrainttemplate.spec.crd.spec.validation.openAPIV3Schema is defined %}
+    {% if constrainttemplate.spec.crd.spec.validation.openAPIV3Schema.get("properties",{}) | length > 0 %}
     <div class="ui segment">
       <h5 class="header">Parameters schema</h5>
       <div class="ui styled fluid accordion">
@@ -65,7 +66,7 @@
         </div>
         
         <div class="ui horizontal very relaxed divided list content">
-          {% for property, value in constrainttemplate.spec.crd.spec.validation.openAPIV3Schema.get("properties",{}).items() %}
+          {% for property, value in constrainttemplate.spec.crd.spec.validation.openAPIV3Schema.properties.items() %}
           <div class="top aligned item">
             <div class="content">
               <div class="header">{{ property }}</div>
@@ -77,6 +78,7 @@
 
       </div>
     </div>
+    {% endif %}
     {% endif %}
 
     <div class="ui segment">

--- a/app/templates/constrainttemplates.html
+++ b/app/templates/constrainttemplates.html
@@ -55,6 +55,7 @@
       </div>
     {% endfor %}
 
+    {% if 'openAPIV3Schema' in constrainttemplate.spec.crd.spec.validation %}
     {% if constrainttemplate.spec.crd.spec.validation is defined and constrainttemplate.spec.crd.spec.validation.openAPIV3Schema.properties is defined %}
     <div class="ui segment">
       <h5 class="header">Parameters schema</h5>
@@ -65,7 +66,7 @@
         </div>
         
         <div class="ui horizontal very relaxed divided list content">
-          {% for property, value in constrainttemplate.spec.crd.spec.validation.openAPIV3Schema.properties.items() %}
+          {% for property, value in constrainttemplate.spec.crd.spec.validation.openAPIV3Schema.get("properties",{}).items() %}
           <div class="top aligned item">
             <div class="content">
               <div class="header">{{ property }}</div>
@@ -77,6 +78,7 @@
 
       </div>
     </div>
+    {% endif %}
     {% endif %}
 
     <div class="ui segment">

--- a/app/templates/constrainttemplates.html
+++ b/app/templates/constrainttemplates.html
@@ -55,8 +55,7 @@
       </div>
     {% endfor %}
 
-    {% if 'openAPIV3Schema' in constrainttemplate.spec.crd.spec.validation %}
-    {% if constrainttemplate.spec.crd.spec.validation is defined and constrainttemplate.spec.crd.spec.validation.openAPIV3Schema.properties is defined %}
+    {% if constrainttemplate.spec.crd.spec.validation is defined and constrainttemplate.spec.crd.spec.validation.openAPIV3Schema is defined %}
     <div class="ui segment">
       <h5 class="header">Parameters schema</h5>
       <div class="ui styled fluid accordion">
@@ -78,7 +77,6 @@
 
       </div>
     </div>
-    {% endif %}
     {% endif %}
 
     <div class="ui segment">


### PR DESCRIPTION
At the moment if there are policy templates which doesn't have `properties` or are without defined `openAPIV3Schema` field, constrainttemplates page will fail with exception.

This PR is adding some check if above exists in the jinja template.