### PR TITLE
Explicitly set the number of replicas

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   name: gatekeeper-policy-manager
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: gatekeeper-policy-manager


### PR DESCRIPTION
If the replicas field is not explicitly set it
defaults to 1.

Although this doesn't seem to be a problem some
Gitops tools (e.g. flux) use 'kubectl apply -f'
under the hood and will not be able to reconcile
the state if someone manually scales down the
deployment and replicas are not explicitly set