### PR TITLE
Update ingress template in helm chart to support k8s 1.22

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ keywords: ["opa", "gatekeeper", "policies", "ui", "dashboard", "web", "rego", "w
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,11 +1,13 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "gatekeeper-policy-manager.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
+{{ else }}
 apiVersion: extensions/v1beta1
-{{- end }}
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -15,6 +17,37 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- range $key, $value := .Values.ingress.hosts }}
+    - host: {{ $value.host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            path: {{ . }}
+            pathType: {{ default "ImplementationSpecific" $value.pathType }}
+        {{- end }}
+{{- end }}
+{{ else }}
 spec:
   {{- if .Values.ingress.tls }}
   tls:
@@ -39,3 +72,4 @@ spec:
           {{- end }}
     {{- end }}
   {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -39,6 +39,7 @@ service:
 
 ingress:
   enabled: false
+  # ingressClassName: "nginx"
   annotations: {}
     #kubernetes.io/ingress.class: "nginx"
     #nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
@@ -55,6 +56,7 @@ ingress:
   hosts:
     - host: gpm.local
       paths: []
+      # pathType: ImplementationSpecific
   tls: []
   #  - secretName: gpm-tls
   #    hosts:


### PR DESCRIPTION
As mentioned in https://github.com/sighupio/gatekeeper-policy-manager/issues/361, the chart install currently breaks as the ingress v1beta1 APIs were deprecated from 1.22 onwards.

I did my best to replicate the current values.yaml behaviour in the new ingress template.

I updated the `Chart.yaml` with a minor version bump as well.