### PR TITLE
fix(helm): fix kubeconfig secret name for multicluster

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
       volumes:
         - name: kubeconfig
           secret:
-            secretName: kubeconfig
+            secretName: {{ include "gatekeeper-policy-manager.fullname" . }}-multicluster
           {{- end -}}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
* Fix `secretName` for multicluster kubeconfig.