### PR TITLE
Fix: improve constraint violations table

### DIFF
--- a/app/web-client/src/pages/Constraints/Component.tsx
+++ b/app/web-client/src/pages/Constraints/Component.tsx
@@ -217,37 +217,28 @@ function SingleConstraint(item: IConstraint, context?: string) {
                   <EuiFlexGroup direction="column" gutterSize="s">
                     <EuiFlexItem>
                       <EuiBasicTable
+                        tableLayout="auto"
                         items={item.status.violations}
                         columns={[
                           {
                             field: "enforcementAction",
                             name: "Action",
-                            truncateText: true,
-                            width: "8%",
                           },
                           {
                             field: "kind",
                             name: "Kind",
-                            truncateText: true,
-                            width: "10%",
                           },
                           {
                             field: "namespace",
                             name: "Namespace",
-                            truncateText: true,
-                            width: "10%",
                           },
                           {
                             field: "name",
                             name: "Name",
-                            truncateText: true,
-                            width: "15%",
                           },
                           {
                             field: "message",
                             name: "Message",
-                            truncateText: false,
-                            width: "60%",
                           },
                         ]}
                       />

--- a/app/web-client/src/pages/Constraints/Component.tsx
+++ b/app/web-client/src/pages/Constraints/Component.tsx
@@ -505,7 +505,7 @@ function ConstraintsComponent() {
         >
           <EuiPage
             paddingSize="none"
-            restrictWidth={1200}
+            restrictWidth={1440}
             grow={true}
             style={{ position: "relative" }}
             className="gpm-page gpm-page-constraints"


### PR DESCRIPTION
This PR introduces:
- stop truncating text in the Constraints' violations table.
- increase the width for the Constraints view to show more data on bigger screens. We left the other views on the previous width on purpose because the text paragraphs get too wide, but showing better the table makes it acceptable in the constraints view.

Fixes #455 

Here's a screenshot
<img width="1792" alt="Screenshot 2022-10-06 at 18 27 13" src="https://user-images.githubusercontent.com/6362698/194367766-229611fb-91bc-48ed-8b8e-b4ebe399a64b.png">
