### PR TITLE
fix: make one GET to /logout to avoid CORS issues

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -434,13 +434,8 @@ def health():
 # Only set up this routes if authentication has been enabled
 if app.config.get("AUTH_ENABLED") == "OIDC":
 
-    @app.route("/logout", methods=["POST"])
-    @auth.oidc_logout
-    def logout():
-        """End session locally"""
-        return {}
-
     @app.route("/logout", methods=["GET"])
+    @auth.oidc_logout
     def logout_view():
         """End session locally"""
         return send_from_directory(app.static_folder, "index.html")

--- a/app/web-client/src/App.tsx
+++ b/app/web-client/src/App.tsx
@@ -15,9 +15,9 @@ import { ConstraintTemplates } from "./pages/ConstraintTemplates";
 import { Constraints } from "./pages/Constraints";
 import { Configurations } from "./pages/Configurations";
 import { Error } from "./pages/Error";
-import {Logout} from "./pages/Logout";
+import { Logout } from "./pages/Logout";
 import { NotFound } from "./pages/NotFound";
-import {theme} from "./theme";
+import { theme } from "./theme";
 import "./App.scss";
 
 function App() {
@@ -29,7 +29,7 @@ function App() {
       modify={theme}
     >
       <ContextProvider>
-        { pathname === "/logout" ? null : <Header />  }
+        {pathname === "/logout" ? null : <Header />}
         <Routes>
           <Route path={`/constrainttemplates`}>
             <Route path=":context" element={<ConstraintTemplates />} />

--- a/app/web-client/src/components/Header/Component.tsx
+++ b/app/web-client/src/components/Header/Component.tsx
@@ -90,14 +90,7 @@ function HeaderComponent() {
     event: MouseEvent<HTMLButtonElement>
   ): void => {
     event.preventDefault();
-
-    fetch(`${context.apiUrl}logout`, { method: "POST" }).finally(
-      () => {
-        setTimeout(() => {
-          window.location.replace("/logout");
-        }, 1000);
-      }
-    );
+    window.location.replace("/logout");
   };
 
   const onChangeContext = (value: string) => {


### PR DESCRIPTION
This PR drops the POST endpoint for `/logout` and uses only the GET endpoint to avoid CORS issues when logging out.

@Al-Pragliola  I'm not 100% sure why we were using the POST with fetch and then the GET. I did not find any regression in switching to just GET.

Fixes #725 