### PR TITLE
fix: show tooltip for long context names

### DIFF
--- a/app/web-client/src/components/Header/Component.tsx
+++ b/app/web-client/src/components/Header/Component.tsx
@@ -63,8 +63,8 @@ function HeaderComponent() {
         dropdownDisplay: (
           <EuiText
             size="s"
+            title={k8sContext}
             style={{
-              maxWidth: "200px",
               overflow: "hidden",
               textOverflow: "ellipsis",
               whiteSpace: "nowrap",
@@ -157,12 +157,14 @@ function HeaderComponent() {
                   </p>
                 </EuiText>
                 <EuiSuperSelect
-                  style={{ width: "200px" }}
                   options={optionsFromContexts}
                   valueOfSelected={decodeURIComponent(
                     context.currentK8sContext,
                   )}
                   onChange={(value) => onChangeContext(value)}
+                  hasDividers
+                  placeholder="change current context"
+                  title={decodeURIComponent(context.currentK8sContext)}
                 />
               </EuiHeaderSectionItem>
             )}


### PR DESCRIPTION
- Show tooltip whit the complete context name when hovering with the mouse pointer
- Drop the maximum width constraint
- Add placeholder text
- Add divider between options for clarity

Fixes #980

<img width="504" alt="image" src="https://github.com/sighupio/gatekeeper-policy-manager/assets/6362698/af0e98fe-5b5b-490d-adf5-b50c7f8cbb7e">

This branch is based on #981 