### PR TITLE
Allow setting secret key by referencing a present/custom secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tests/e2e/test-results
 build/
 node_modules/
 static-content/
+*.tgz

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -19,7 +19,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.10.0"
+version: "0.11.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -62,10 +62,17 @@ spec:
             - name: GPM_PREFERRED_URL_SCHEME
               value: {{ required "A valid .Values.config.preferredURLScheme entry required! Choose either http or https" .Values.config.preferredURLScheme | quote }}
             - name: GPM_SECRET_KEY
+              {{- if .Values.config.secretKey }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "gatekeeper-policy-manager.fullname" . }}
                   key: secretKey
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.secretRef }}
+                  key: secretKey
+              {{- end }}
             {{- if .Values.config.oidc.enabled }}
             - name: GPM_AUTH_ENABLED
               value: "OIDC"

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.secretKey }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ metadata:
     {{- include "gatekeeper-policy-manager.labels" . | nindent 4 }}
 stringData:
   secretKey: {{ required "A valid .Values.config.secretKey entry required! Choose a secure string" .Values.config.secretKey | quote }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -121,7 +121,11 @@ topologySpreadConstraints: []
 config:
   preferredURLScheme: http
   logLevel: info
-  secretKey:
+  # secret in plain text
+  secretKey: null
+  # name of the secret containing the secret key. if set, config.secretKey should be null!
+  # supported fields: secretKey
+  secretRef: null
   multiCluster:
     enabled: false
     kubeconfig: |


### PR DESCRIPTION
Hello @ralgozino & @Al-Pragliola 

Right now you have to set the `config.secretKey` in Helm values **in plain text** to set the `GPM_SECRET_KEY` env var. I thought it would be beneficial to allow users to set the env var by referencing a secret that can be deployed separately.

To make this possible, I refactored the Helm Chart slightly. Now it's possible to set `config.secretRef` in Helm values. If this field is set (and `config.secretKey` is set to `null`), the `GPM_SECRET_KEY` env var in deployment is set from the custom secret (not the default one).

I have tested the changes in a production-grade k8s cluster.