### PR TITLE
Modify deployment template to support passing GPM_SECRET_KEY as env var

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -75,18 +75,19 @@ spec:
               value: {{ .Values.config.logLevel | upper | quote }}
             - name: GPM_PREFERRED_URL_SCHEME
               value: {{ required "A valid .Values.config.preferredURLScheme entry required! Choose either http or https" .Values.config.preferredURLScheme | quote }}
+            {{- if .Values.config.secretKey }}
             - name: GPM_SECRET_KEY
-              {{- if .Values.config.secretKey }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "gatekeeper-policy-manager.fullname" . }}
                   key: secretKey
-              {{- else }}
+            {{- else if .Values.config.secretRef }}
+            - name: GPM_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.secretRef }}
                   key: secretKey
-              {{- end }}
+            {{- end }}
             {{- if .Values.config.oidc.enabled }}
             - name: GPM_AUTH_ENABLED
               value: "OIDC"


### PR DESCRIPTION
This PR makes it possible to pass the `GPM_SECRET_KEY` via `extraEnvs` to allow runtime secret injection eg. via Vault secrets webhook.