### PR TITLE
feat(frontend): add support for rego v1 in constraint template's rego definition

### DIFF
--- a/app/web-client/src/pages/ConstraintTemplates/Component.tsx
+++ b/app/web-client/src/pages/ConstraintTemplates/Component.tsx
@@ -145,7 +145,7 @@ function SingleConstraintTemplate(
             paddingSize="none"
           >
             <EuiCodeBlock lineNumbers language="rego">
-              {item.spec.targets[0].rego}
+              {item.spec.targets[0].rego ?? item.spec.targets[0].code?.filter(code => code.engine == "Rego")[0]?.source.rego}
             </EuiCodeBlock>
           </EuiAccordion>
         </EuiFlexItem>

--- a/app/web-client/src/pages/ConstraintTemplates/types.ts
+++ b/app/web-client/src/pages/ConstraintTemplates/types.ts
@@ -7,9 +7,18 @@ import { IConstraint } from "../Constraints/types";
  */
 
 export interface IConstraintTemplateSpecTarget {
-  rego: string;
+  rego?: string;
   libs?: string[];
   target: string;
+  code?: IConstraintTemplateSpecTargetCode[];
+}
+
+export interface IConstraintTemplateSpecTargetCode {
+  engine: string;
+  source: {
+    rego: string;
+    version: string;
+  };
 }
 
 export interface IConstraintTemplateSpecStatusPod {


### PR DESCRIPTION
### Summary 💡
This PR adds support for Rego v1 definition on the Constraint Template page, while still supporting Rego v0.

<!-- If there's an existing issue for your change, please link to it below inserting a link or the issue number: -->

<!--
If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
for example is an error message that other users could get and google it.
-->

### Description 📝
To support Rego v1, gatekeeper [has changed the structure of Constraint Template's CRD](https://github.com/open-policy-agent/gatekeeper/blob/7a8a66c6b71c6519e8e3ed0fecbff75cd00399f3/charts/gatekeeper/crds/constrainttemplate-customresourcedefinition.yaml#L71-L89). Because of this, when using this structure, GPM does not display the Rego definition as the `item.spec.targets[0].rego` field does not exist. Instead, the Rego policy is located in `item.spec.targets[_].code[_].rego`. Even though `code` is an array, it cannot have multiple Rego definitions because Gatekeeper does not let us create such a Constraint Template (see screenshot below). Hence, we can always take the first element of the array filtered by `engine == "Rego"`. Filtering is needed for validation and in case Gatekeeper will support not only Rego in the future (otherwise why such a structure was added?).

I also had to edit the `IConstraintTemplateSpecTarget` interface, because due to changes in Gatekeeper the `rego` field became optional, but the `code` field appeared.

### Screenshots
1. Rego v1 (top) with Rego v0 (bottom)

![image](https://github.com/user-attachments/assets/8d8c1eac-6ee9-41a8-9894-880c59f26bb0)

2. Cannot create two policies with the same engine

![image](https://github.com/user-attachments/assets/5fcdc42f-54ca-4970-a63a-5c2351280790)

### Tests performed 🧪
- [x] Tested on Gatekeeper 3.19.1
- [x] Applied templates with Rego v0 (old structure) and Rego v1 (new structure)
- [x] Applied template with invalid engine name (not rego)

Tested manifests:
[test-files-gpm.zip](https://github.com/user-attachments/files/20741966/test-files-gpm.zip)