### PR TITLE
fix: add GPM_SKIP_TLS_VERIFY env var to bypass SSL verification on EKS

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -31,7 +31,7 @@ from flask_pyoidc.user_session import UserSession
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 from kubernetes.config.config_exception import ConfigException
-from urllib3.exceptions import MaxRetryError, NewConnectionError
+from urllib3.exceptions import MaxRetryError, NewConnectionError, SSLError
 
 app = Flask(__name__, static_folder="static-content", template_folder="templates")
 
@@ -155,6 +155,13 @@ except config.ConfigException as e:
             "assuming to be running inside a Kubernetes cluster"
         )
         config.load_incluster_config()
+        if os.environ.get("GPM_SKIP_TLS_VERIFY", "").lower() == "true":
+            app.logger.warning(
+                "GPM_SKIP_TLS_VERIFY is set: disabling TLS certificate verification for Kubernetes API calls"
+            )
+            c = client.Configuration.get_default_copy()
+            c.verify_ssl = False
+            client.Configuration.set_default(c)
         app.logger.info("In cluster configuration loaded successfully.")
         app.config["MODE"] = "CLUSTER"
     else:
@@ -247,6 +254,12 @@ def get_constraints(context=None):
             plural="",
             name="",
         )
+    except SSLError as e:
+        return {
+            "error": "TLS certificate verification failed connecting to Kubernetes API",
+            "action": "Set GPM_SKIP_TLS_VERIFY=true if the cluster CA is missing AKI/SKI extensions (e.g. EKS)",
+            "description": str(e),
+        }, 500
     except NewConnectionError as e:
         return {
             "error": "Could not connect to Kubernetes Cluster",
@@ -372,6 +385,12 @@ def get_constrainttemplates(context=None):
                         f"No constraints found for Constraint Template {ct['metadata']['name']}"
                     )
 
+    except SSLError as e:
+        return {
+            "error": "TLS certificate verification failed connecting to Kubernetes API",
+            "action": "Set GPM_SKIP_TLS_VERIFY=true if the cluster CA is missing AKI/SKI extensions (e.g. EKS)",
+            "description": str(e),
+        }, 500
     except NewConnectionError as e:
         return {
             "error": "Could not connect to Kubernetes Cluster",
@@ -422,6 +441,12 @@ def get_gatekeeperconfigs(context=None):
             plural="configs",
             name="",
         )
+    except SSLError as e:
+        return {
+            "error": "TLS certificate verification failed connecting to Kubernetes API",
+            "action": "Set GPM_SKIP_TLS_VERIFY=true if the cluster CA is missing AKI/SKI extensions (e.g. EKS)",
+            "description": str(e),
+        }, 500
     except NewConnectionError as e:
         return {
             "error": "Could not connect to Kubernetes Cluster",


### PR DESCRIPTION
### **Summary** 💡

  Clusters with CA certificates missing the Authority Key Identifier (AKI) extension cause Python ssl to reject the connection. On managed clusters like EKS the CA cannot be
  re-issued, so this adds an opt-in escape hatch: set GPM_SKIP_TLS_VERIFY=true to disable verify_ssl on the kubernetes client. Also catches SSLError in all three API route
  handlers so it returns a descriptive JSON error instead of an unhandled 500.

### **Closes:**

### *Description* 📝

  Some Kubernetes clusters — particularly older EKS clusters provisioned before ~2021 — have a cluster CA certificate that was generated without the X509v3 Authority Key
  Identifier extension. Since Python 3.10+ / OpenSSL 1.1.1k+, ssl strictly requires AKI to be present and rejects the connection with:

 ` [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier`
<img width="752" height="494" alt="image" src="https://github.com/user-attachments/assets/c6e320cf-627e-429e-baa2-220052394136" />

  On managed clusters like EKS, the control plane CA key is not accessible, so re-issuing the certificate with the missing extension is not possible without a full (and
  disruptive) CA rotation.

### *Changes*:

  - Added GPM_SKIP_TLS_VERIFY environment variable. When set to true, the kubernetes client's verify_ssl is set to False after load_incluster_config() is called. The setting
  emits a warning log so it is visible in application logs.
  - Added SSLError exception handling to all three API route handlers (/api/v1/constraints/, /api/v1/constrainttemplates/, /api/v1/configs/) so SSL failures surface as a
  structured JSON response with an actionable message instead of an unhandled 500 crash.

### *Usage*:

  Add the following environment variable to the GPM deployment in the affected cluster:
```
  env:
    - name: GPM_SKIP_TLS_VERIFY
      value: "true"
```
### Breaking Changes 💔

  None. The GPM_SKIP_TLS_VERIFY variable defaults to unset (verification enabled), so existing deployments are unaffected.

### **Tests performed** 🧪

  - [X] Deployed on the affected EKS cluster with GPM_SKIP_TLS_VERIFY=true — constraints, constraint templates and configs endpoints return data successfully
  - [X] Deployed without the env var on a cluster with a valid CA — behaviour unchanged, TLS verification still active
  - [X] Verified warning log appears when the env var is set

### **Future work**🔧

  - A better long-term fix would be to support mounting a custom CA bundle via GPM_CA_BUNDLE_PATH, allowing users to provide a corrected CA certificate without fully disabling TLS verification.