### PR TITLE
Support deploying GPM behind a reverse proxy on a subpath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 FROM --platform=$BUILDPLATFORM node:lts-alpine AS node
+ARG PUBLIC_URL=""
+ENV PUBLIC_URL=$PUBLIC_URL
 WORKDIR /web-client
 COPY app/web-client/package.json app/web-client/yarn.lock ./
 RUN yarn install && yarn cache clean

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ helm upgrade --install --namespace gatekeeper-system --set image.tag=v1.1.1 --va
 > [!IMPORTANT]
 > Don't forget to replace `my-values.yaml` with the path to your values file.
 
+### Running behind a reverse proxy on a subpath
+
+GPM assumes by default that it's served from the domain root. If you're putting it behind a reverse proxy on a subpath, for example `example.com/gpm`, set the `PUBLIC_URL` build argument when building the image so the frontend's router and API calls use that subpath instead of `/`.
+
+Build the image with:
+
+```bash
+docker build --build-arg PUBLIC_URL=/gpm -t gatekeeper-policy-manager:subpath .
+```
+
+This uses [Create React App's standard `PUBLIC_URL` mechanism](https://create-react-app.dev/docs/using-the-public-folder/). It sets the router's `basename` and the frontend's API base path at build time, so the subpath is baked into the built assets. If `PUBLIC_URL` is left unset, GPM behaves exactly as before and is served from `/`.
+
+The image published on quay.io is built for the root path. If you need a subpath deployment, build your own image with the argument above and push it to your own registry, or reference the Dockerfile from your CI pipeline with the same `--build-arg`.
+
 ## Running locally
 
 GPM can also be run locally using docker and a `kubeconfig`, assuming that the `kubeconfig` file you want to use is located at `~/.kube/config` the command to run GPM locally would be:
@@ -95,8 +109,8 @@ GPM is a stateless application, but it can be configured using environment varia
 | `GPM_OIDC_TOKEN_ENDPOINT`         | OIDC TOKEN Endpoint (optional, setting this parameter disables the discovery of the rest of the provider configuration, set all the other values also if setting this one)                                                        |                        |
 | `GPM_OIDC_INTROSPECTION_ENDPOINT` | OIDC Introspection Endpoint (optional, setting this parameter disables the discovery of the rest of the provider configuration, set all the other values also if setting this one)                                                |                        |
 | `GPM_OIDC_USERINFO_ENDPOINT`      | OIDC Userinfo Endpoint (optional, setting this parameter disables the discovery of the rest of the provider configuration, set all the other values also if setting this one)                                                     |                        |
-| `GPM_OIDC_END_SESSION_ENDPOINT`   | OIDC End Session Endpoint (optional, setting this parameter disables the discovery of the rest of the provider configuration, set all the other values also if setting this one)                                                  |                        |
-| `GPM_SKIP_TLS_VERIFY`             | Skip TLS certificate verifications while connecting to the Kubernetes API Server. USE WITH CAUTION.                                                                                                                               | `false`                |
+| `GPM_OIDC_END_SESSION_ENDPOINT`   | OIDC End Session Endpoint (optional, setting this parameter disables the discovery of the rest of the provider configuration, set all the other values also if setting this one)                                                   |                        |
+| `GPM_SKIP_TLS_VERIFY`             | Skip TLS certificate verifications while connecting to the Kubernetes API Server. USE WITH CAUTION.                                                                                                                               | `false`               |
 
 >[!WARNING]
 > Please notice that OIDC Authentication is in beta state. It has been tested to work with Keycloak as a provider.

--- a/app/web-client/src/AppContextProvider.tsx
+++ b/app/web-client/src/AppContextProvider.tsx
@@ -28,7 +28,7 @@ type K8sContextsResponse = IK8sContext[][] | IK8sContext[];
 const getDefaultContext = (): IApplicationContextData => {
   return {
     apiUrl:
-      process.env.NODE_ENV !== "production" ? (process.env?.REACT_APP_LOCAL_GPM_SERVER_URL ?? "missing local url") : "/",
+      process.env.NODE_ENV !== "production" ? (process.env?.REACT_APP_LOCAL_GPM_SERVER_URL ?? "missing local url") : `${process.env.PUBLIC_URL}/`,
     authEnabled:
       JSON.parse(localStorage.getItem("authEnabled") ?? "false") || false,
     currentK8sContext: localStorage.getItem("currentK8sContext") || "",

--- a/app/web-client/src/index.tsx
+++ b/app/web-client/src/index.tsx
@@ -12,7 +12,7 @@ import { BrowserRouter } from "react-router-dom";
 import "./index.scss";
 
 ReactDOM.render(
-    <BrowserRouter basename={process.env.PUBLIC_URL}>
+  <BrowserRouter basename={process.env.PUBLIC_URL}>
     <App />
   </BrowserRouter>,
   document.getElementById("root")

--- a/app/web-client/src/index.tsx
+++ b/app/web-client/src/index.tsx
@@ -12,7 +12,7 @@ import { BrowserRouter } from "react-router-dom";
 import "./index.scss";
 
 ReactDOM.render(
-  <BrowserRouter>
+    <BrowserRouter basename={process.env.PUBLIC_URL}>
     <App />
   </BrowserRouter>,
   document.getElementById("root")


### PR DESCRIPTION
Closes #452. GPM assumes it's served from the domain root, so it breaks behind a reverse proxy on a subpath (e.g. example.com/gpm): the built index.html and API calls use absolute root paths, and the router has no basename.

This wires up Create React App's standard PUBLIC_URL mechanism instead of hardcoding a path, so the subpath stays configurable per deployment. index.tsx passes basename={process.env.PUBLIC_URL} to BrowserRouter. AppContextProvider.tsx's production apiUrl was hardcoded to "/", now it respects PUBLIC_URL. Dockerfile adds an ARG/ENV PUBLIC_URL (default empty) in the frontend build stage so it can be set at build time, e.g. docker build --build-arg PUBLIC_URL=/gpm .

When PUBLIC_URL is unset, nothing changes, so this is backward compatible.

One thing to flag: this is build-time config, so the published quay.io image would need a rebuild with PUBLIC_URL set to actually deploy under a subpath. I verified both TSX changes compile cleanly with esbuild. I don't have a reverse-proxy setup to test the full runtime behavior, so a maintainer check there would help.