### PR TITLE
feat: vendor alpine

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -186,6 +186,29 @@ trigger:
       - refs/tags/gatekeeper-policy-manager-*
 
 steps:
+  # On Dependabot branches, refresh the vendored Alpine to the version package.json now pins, before
+  # the image is built. This runs in the same shared workspace as the build step below, so the image
+  # (and the e2e that runs it) tests the bumped Alpine instead of the committed one. Skipped on every
+  # other branch, where the committed file already matches (check-alpine-version guards that).
+  - name: vendor-alpine
+    image: quay.io/sighup/mise:v2026.8.6
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
+    commands:
+      - "(flock -w 1800 9 || exit 1; mise install) 9>/mise-data/.mise-install.lock"
+      - eval "$(mise activate bash --shims)"
+      - mise run vendor-alpine
+    when:
+      ref:
+        include:
+          - refs/heads/dependabot/**
+
   - name: build
     image: docker:dind
     pull: always
@@ -206,6 +229,9 @@ steps:
       - "docker buildx build --load --platform linux/amd64 -t $${CONTAINER_IMAGE_NAME}:$${CONTAINER_IMAGE_TAG} $${BUILD_CONTEXT}"
 
 volumes:
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
   - name: dockerconfig
     host:
       path: /root/.docker/config.json

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
     schedule:
       interval: "weekly"
 
+  # Vendored browser assets. The root package.json pins Alpine.js, which ships as
+  # static/ssr/alpine.min.js; after a bump PR merges, run `mise run vendor-alpine` to refresh the
+  # vendored file (the check-alpine-version CI task fails until it matches).
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   # Playwright end-to-end tests. NOTE: the Playwright version here must match the
   # mcr.microsoft.com/playwright image tag in .drone.yml, so a bump PR needs a manual
   # follow-up to update those image tags in the same change.

--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ GPM is written in Go. It uses the Echo framework and renders the UI on the serve
 library's `html/template`, plus a small amount of Alpine.js for interactivity. There is no separate
 frontend build.
 
+Alpine.js is vendored as `static/ssr/alpine.min.js`. Its version is pinned in `package.json` so
+Dependabot tracks it; after a bump, run `mise run vendor-alpine` to refresh the vendored file (the
+`check-alpine-version` task, part of `mise run lint`, fails if the two drift).
+
 To develop GPM, run these commands:
 
 ```bash

--- a/mise.toml
+++ b/mise.toml
@@ -33,9 +33,10 @@ description = "shellcheck the shell scripts"
 run = 'shellcheck $(find . -name "*.sh" -not -path "*/node_modules/*")'
 
 [tasks.lint]
-description = "run golangci-lint (and shellcheck via the lint-shell dep)"
-# lint-shell runs first, in the same qa step, so a shell-script fault fails CI too.
-depends = ["lint-shell"]
+description = "run golangci-lint (plus the shell and Alpine-version checks via deps)"
+# The deps run first in the same qa step, so a shell-script fault or a stale vendored Alpine fails
+# CI too.
+depends = ["lint-shell", "check-alpine-version"]
 run = "golangci-lint run --config=.rules/.golangci.yml ./..."
 
 [tasks."lint-fix"]
@@ -122,6 +123,34 @@ run = [
   "kustomize build . > gpm.yaml",
   "helm template --set config.secretKey=e2e chart > rendered_chart.yaml",
 ]
+
+[tasks."vendor-alpine"]
+description = "re-download the vendored Alpine.js (version from package.json) into static/ssr/alpine.min.js"
+# The version is pinned in package.json so Dependabot can bump it; this fetches that version. cdnjs,
+# jsdelivr and unpkg all serve the same npm dist/cdn.min.js, so the bytes match whichever mirror.
+run = """
+version=$(node -p "require('./package.json').dependencies.alpinejs.replace(/[^0-9.]/g,'')")
+url="https://cdnjs.cloudflare.com/ajax/libs/alpinejs/${version}/cdn.min.js"
+curl -fsSL "$url" -o static/ssr/alpine.min.js
+bytes=$(wc -c < static/ssr/alpine.min.js)
+[ "$bytes" -gt 20000 ] || { echo "downloaded file is only ${bytes} bytes; aborting" >&2; exit 1; }
+grep -q "\\"${version}\\"" static/ssr/alpine.min.js || { echo "downloaded build does not report version ${version}" >&2; exit 1; }
+echo "vendored Alpine ${version} (${bytes} bytes) from ${url}"
+"""
+
+[tasks."check-alpine-version"]
+description = "fail if static/ssr/alpine.min.js drifts from the Alpine version pinned in package.json"
+# Guards the vendored file against the manifest, so a Dependabot bump that forgets to re-run
+# vendor-alpine fails CI (same idea as check-go-version for the Dockerfile).
+run = """
+want=$(node -p "require('./package.json').dependencies.alpinejs.replace(/[^0-9.]/g,'')")
+have=$(grep -oE 'version:"[0-9.]+"' static/ssr/alpine.min.js | head -1 | tr -dc '0-9.')
+if [ "$want" != "$have" ]; then
+  echo "alpine.min.js reports ${have} but package.json pins ${want}; run 'mise run vendor-alpine'" >&2
+  exit 1
+fi
+echo "Alpine aligned across package.json and alpine.min.js: ${want}"
+"""
 
 [tasks."gen:screenshots"]
 description = "capture the README screenshots from a running GPM (set GPM_BASE_URL, default http://localhost:8080)"

--- a/mise.toml
+++ b/mise.toml
@@ -143,6 +143,15 @@ description = "fail if static/ssr/alpine.min.js drifts from the Alpine version p
 # Guards the vendored file against the manifest, so a Dependabot bump that forgets to re-run
 # vendor-alpine fails CI (same idea as check-go-version for the Dockerfile).
 run = """
+# On a Dependabot branch the vendored file legitimately lags the manifest: Dependabot only edits
+# package.json, and the build pipeline re-vendors Alpine so the e2e run tests the bumped version.
+# Skip the drift check there; it still guards main, where the refreshed file must land.
+case "${DRONE_SOURCE_BRANCH:-${DRONE_BRANCH:-}}" in
+  dependabot/*)
+    echo "Dependabot branch: CI re-vendors Alpine and e2e-tests it; skipping the drift check"
+    exit 0
+    ;;
+esac
 want=$(node -p "require('./package.json').dependencies.alpinejs.replace(/[^0-9.]/g,'')")
 have=$(grep -oE 'version:"[0-9.]+"' static/ssr/alpine.min.js | head -1 | tr -dc '0-9.')
 if [ "$want" != "$have" ]; then

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gatekeeper-policy-manager-web-assets",
+  "private": true,
+  "description": "Pins the versions of the browser assets vendored under static/ssr (Alpine.js) so Dependabot can track them. Nothing is built or installed from here; run 'mise run vendor-alpine' to refresh the vendored file after a bump.",
+  "dependencies": {
+    "alpinejs": "3.14.9"
+  }
+}


### PR DESCRIPTION
### Summary 💡

Vendor Alpine.js and automate verions checks and tracking.

### Description 📝

Alpine.js ships as the vendored static/ssr/alpine.min.js, which Dependabot cannot watch directly. Pin its version in a minimal root package.json (the only manifest Dependabot understands for a browser lib) and add an npm Dependabot entry, so version bumps arrive as PRs.

`mise run vendor-alpine` reads that pinned version and re-downloads the matching cdn.min.js, so bumping is a one-line edit plus a task run, not a hand-copied minified file. `check-alpine-version` (wired into `mise run lint`) fails if the vendored file drifts from the manifest, so a Dependabot bump that forgets to re-vendor is caught in CI -- the same guard idea as check-go-version.

A Dependabot bump only edits package.json; the vendored static/ssr/alpine.min.js still holds the old build. Without help CI would either block on check-alpine-version or run the e2e against the old Alpine.

On dependabot/** branches, re-vendor Alpine in the build pipeline before the image is built, in the same shared workspace, so the image the e2e run exercises embeds the bumped version. The e2e pipeline already triggers on those branches. check-alpine-version skips there (Dependabot cannot re-vendor) and still guards main, where the refreshed alpine.min.js must land.

A red e2e on the bump PR is now the signal not to merge, instead of merging, testing and reverting by hand.

Relates:
- #1488 

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] CI is green

### Future work 🔧

None