### PR TITLE
fix(e2e): wait for Gatekeeper's audit to settle

### DIFF
--- a/tests/e2e/tests/constraints.spec.ts
+++ b/tests/e2e/tests/constraints.spec.ts
@@ -7,7 +7,30 @@
 import { test, expect } from "@playwright/test";
 
 test("page constraints snapshot", async ({ page }) => {
-  await page.goto("constraints/");
+  // Converging Gatekeeper's audit can take several cycles, so allow well beyond the default 30s.
+  test.setTimeout(220_000);
+
+  // The page is server-rendered from Gatekeeper's audit status, which converges a few audit cycles
+  // after deploy (and after the [CHART] test churns the cluster right before this runs). Until it
+  // settles, a Constraint can show a "not audited yet" banner, and the per-pod status block grows as
+  // each controller/audit pod reports in. Both change the page height, so a full-page snapshot taken
+  // too early fails on size. The page does not auto-refresh, so reload until it is settled: no
+  // banner, and a height that no longer changes between two reloads.
+  let previousHeight = -1;
+  await expect(async () => {
+    await page.goto("constraints/");
+    await expect(page.getByText("has probably not audited it yet")).toHaveCount(
+      0,
+    );
+    const height = await page.evaluate(() => document.body.scrollHeight);
+    const settled = height === previousHeight;
+    previousHeight = height; // advance before asserting, so the next reload compares against it
+    expect(
+      settled,
+      `constraints page height not stable yet (${height}px)`,
+    ).toBe(true);
+  }).toPass({ timeout: 180_000, intervals: [4_000] });
+
   await expect(page).toHaveScreenshot({
     maxDiffPixels: 100,
     fullPage: true,


### PR DESCRIPTION
### Summary 💡

Wait for Gatekeeper's audit to settle before the constraints snapshot

### Description 📝

The constraints view is server-rendered from Gatekeeper's audit status. Right after deploy, and again while the [CHART] test churns the cluster just before ui-tests, a Constraint can render a "not audited yet" banner and its per-pod status block grows as each controller/audit pod reports in. Both change the page height, so the full-page snapshot intermittently failed on a size mismatch (1671 vs 1742 px) -- a size mismatch hard-fails regardless of maxDiffPixels.

The final audited counts are deterministic (the chart pod is security-compliant, so it adds no violations); only the convergence timing varies. The bats [AUDIT] check only waits for one Constraint and runs before the chart churn, so it does not guarantee a settled page at snapshot time.

The page does not auto-refresh, so reload it until settled: no banner and a height that stops changing between reloads, then snapshot. Verified in the mcr.microsoft.com/playwright:v1.55.1 container against a kind cluster; the settled page matches the committed 1671px baseline.

### Breaking Changes 💔

None

### Tests performed 🧪

NA

### Future work 🔧

NA